### PR TITLE
로깅 기능 추가

### DIFF
--- a/src/main/java/com/wooteco/wiki/auth/configure/WebConfig.java
+++ b/src/main/java/com/wooteco/wiki/auth/configure/WebConfig.java
@@ -9,7 +9,7 @@ public class WebConfig implements WebMvcConfigurer {
     @Override
     public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/**")
-                .allowedOriginPatterns("http://localhost:3000")
+                .allowedOriginPatterns("http://localhost:3000", "https://dev.crew-wiki.site", "https://crew-wiki.site")
                 .allowCredentials(true)
                 .allowedMethods("*");
     }

--- a/src/main/java/com/wooteco/wiki/logging/BusinessLogicLogger.java
+++ b/src/main/java/com/wooteco/wiki/logging/BusinessLogicLogger.java
@@ -1,0 +1,75 @@
+package com.wooteco.wiki.logging;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+import org.springframework.web.util.ContentCachingRequestWrapper;
+
+@Slf4j
+@Aspect
+@Component
+@Order(1)
+public class BusinessLogicLogger {
+
+    @Around("execution(* com.wooteco.wiki.controller.*Controller.*(..)) "
+            + "|| execution(* com.wooteco.wiki.service.*Service.*(..)) "
+            + "|| execution(* com.wooteco.wiki.domain.*.*(..)) "
+            + "|| execution(* com.wooteco.wiki.repository.*Repository.*(..)) ")
+    public Object printLog(ProceedingJoinPoint joinPoint) throws Throwable {
+        String className = joinPoint.getSignature().getDeclaringTypeName();
+        String methodName = joinPoint.getSignature().getName();
+        String type = getBusinessType(className);
+        if (className.contains("Controller")) {
+            printRequestBody();
+        }
+        try {
+            HttpServletRequest request = getRequest();
+            String requestId = (String) request.getAttribute("requestId");
+            log.info("{} = {} {} {}.{}()", "RequestId", requestId, type, className, methodName);
+        } catch (IllegalStateException e) {
+            log.info("{} = {} {} {}.{}()", "Scheduler", className, type, className, methodName);
+        }
+        return joinPoint.proceed();
+    }
+
+    private String getBusinessType(String className) {
+        if (className.contains("Controller")) {
+            return "<<Controller>>";
+        }
+        if (className.contains("Service")) {
+            return "<<Service>>";
+        }
+        if (className.contains("Repository")) {
+            return "<<Repository>>";
+        }
+        if (className.contains("Scheduler")) {
+            return "<<Scheduler>>";
+        }
+        return "";
+    }
+
+    private void printRequestBody() {
+        HttpServletRequest request = getRequest();
+        final ContentCachingRequestWrapper cachingRequest = (ContentCachingRequestWrapper) request;
+        String requestId = (String) cachingRequest.getAttribute("requestId");
+        String logType = "<<Request>>";
+        ObjectMapper objectMapper = new ObjectMapper();
+        try {
+            log.info("{} = {} {} {} = \n{}", "RequestId", requestId, logType, "Body",
+                    objectMapper.readTree(cachingRequest.getContentAsByteArray()).toPrettyString());
+        } catch (Exception e) {
+            log.info("{} = {} {} {} = \n{}", "RequestId", requestId, logType, "Body", " ");
+        }
+    }
+
+    private static HttpServletRequest getRequest() {
+        return ((ServletRequestAttributes) RequestContextHolder.currentRequestAttributes()).getRequest();
+    }
+}

--- a/src/main/java/com/wooteco/wiki/logging/HttpLogger.java
+++ b/src/main/java/com/wooteco/wiki/logging/HttpLogger.java
@@ -1,0 +1,78 @@
+package com.wooteco.wiki.logging;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Enumeration;
+import java.util.List;
+import java.util.UUID;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+import org.springframework.web.util.ContentCachingRequestWrapper;
+import org.springframework.web.util.ContentCachingResponseWrapper;
+
+@Component
+@Slf4j
+public class HttpLogger extends OncePerRequestFilter {
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+        String requestId = UUID.randomUUID().toString();
+        request.setAttribute("requestId", requestId);
+        ContentCachingRequestWrapper wrappingRequest = new ContentCachingRequestWrapper(request);
+        ContentCachingResponseWrapper wrappingResponse = new ContentCachingResponseWrapper(response);
+        printRequestUriAndHeaders(wrappingRequest);
+        filterChain.doFilter(wrappingRequest, wrappingResponse);
+        wrappingResponse.addHeader("requestId", requestId);
+        String responseBodyLog = makeResponseBodyLog(wrappingResponse);
+        wrappingResponse.copyBodyToResponse();
+        List<String> responseHeaderLogs = makeResponseHeaderLogs(requestId, response);
+        printResponseLogs(requestId, responseHeaderLogs, responseBodyLog);
+    }
+
+    private void printRequestUriAndHeaders(ContentCachingRequestWrapper request) {
+        String logType = "<<Request>>";
+        String requestId = (String) request.getAttribute("requestId");
+        log.info("{} = {} {} {} = {}&{}", "RequestId", requestId, logType, "URI", request.getRequestURI(),
+                request.getQueryString());
+        log.info("{} = {} {} {}", "RequestId", requestId, logType, "Headers");
+        Enumeration<String> headerNames = request.getHeaderNames();
+        while (headerNames.hasMoreElements()) {
+            String headerName = headerNames.nextElement();
+            String header = request.getHeader(headerName);
+            log.info("{} = {} {} {} = {}", "RequestId", requestId, logType, headerName, header);
+        }
+    }
+
+    private String makeResponseBodyLog(ContentCachingResponseWrapper responseWrapper) {
+        try {
+            ObjectMapper objectMapper = new ObjectMapper();
+            return objectMapper.readTree(responseWrapper.getContentAsByteArray()).toPrettyString();
+        } catch (IOException e) {
+            return responseWrapper.getContentType() + " body json 아니라 파싱 불가";
+        }
+    }
+
+    private List<String> makeResponseHeaderLogs(String requestId, HttpServletResponse response) {
+        List<String> responseHeaderLogs = new ArrayList<>();
+        responseHeaderLogs.add(String.format("%s = %s %s %s", "RequestId", requestId, "<<Response>>", "Headers"));
+        for (String s : response.getHeaderNames()) {
+            String headerLog = s + " = " + response.getHeader(s);
+            responseHeaderLogs.add(headerLog);
+        }
+        return responseHeaderLogs;
+    }
+
+    private void printResponseLogs(String requestId, List<String> responseHeaderLogs, String responseBodyLog) {
+        for (String s : responseHeaderLogs) {
+            log.info(s);
+        }
+        log.info("{} = {} {} {} = \n{}", "RequestId", requestId, "<<Response>>", "Body", responseBodyLog);
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,13 +1,7 @@
 spring:
   application:
     name: wiki
-  jpa: #jpa 종류
-    hibernate:
-      ddl-auto: update
-    properties:
-      hibernate:
-        format_sql: true #이쁘게 해줌
-logging:
-  level:
-    org.hibernate.SQL: trace #콘솔에 남기는게 아니라 로그로 남음.
-    org.hibernate.type: trace #바인딩된 파라미터까지 볼 수 있음
+  profiles:
+    group:
+      local: local, common
+      product: product, common

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<configuration>
+    <property name="logPath" value="./wiki_log"/>
+    <property name="fileName" value="application_log"/>
+    <property name="maxHistory" value="7"/>
+    <property name="maxFileSize" value="5KB"/>
+    <property name="totalSizeCap" value="1GB"/>
+    <property name="logPattern"
+              value="[%d{yyyy-MM-dd HH:mm:ss}:%-4relative] %green([%thread]) %highlight(%-5level) [%C.%M:%line] - %msg%n"/>
+
+    <!-- Log Appender Module -->
+    <springProfile name="local">
+        <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
+        <appender name="console" class="ch.qos.logback.core.ConsoleAppender">
+            <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
+                <pattern>${logPattern}</pattern>
+            </encoder>
+        </appender>
+        <root>
+            <appender-ref ref="console"/>
+        </root>
+    </springProfile>
+
+    <!-- file Appender Module -->
+    <springProfile name="product">
+        <appender name="file" class="ch.qos.logback.core.rolling.RollingFileAppender">
+            <file>${logPath}//${fileName}.log</file>
+            <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+                <fileNamePattern>application.log.%d{yyyy-MM-dd}.gz</fileNamePattern>
+                <maxHistory>30</maxHistory>
+                <totalSizeCap>5GB</totalSizeCap>
+            </rollingPolicy>
+            <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
+                <pattern>${logPattern}</pattern>
+            </encoder>
+        </appender>
+        <root>
+            <appender-ref ref="file"/>
+        </root>
+    </springProfile>
+</configuration>


### PR DESCRIPTION
## 주의 사항
아래 변경 사항을 적용하기 위해서는 application.yml 을 통한 프로파일 설정이 필요합니다. 여기에는 공개되면 안되는 정보도 다수 포함되어 있기 때문에 깃으로 관리하지 않습니다. **관련 파일은 따로 공유드리겠습니다!**

## 요청에 대한 고유 아이디 부여
**단일 HTTP 요청과 이에 따른 응답에 고유한 requestId가 부여**됩니다. 이는 **모든 응답에 HTTP 헤더로 포함**되게 됩니다. 이를 통해 **요청에 대한 로그 분석이 가능하게 될 것으로 기대**됩니다.

## HTTP 요청 로그 기능
아래 사진 처럼 모든 HTTP 요청이 다음과 같이 URI, 쿼리 스트링, 헤더, 바디가 모두 파싱되어 로그로 남습니다.
<img width="1681" alt="image" src="https://github.com/Crew-Wiki/backend/assets/45223837/6052cb1c-1f9e-4c57-a792-c0154bdffaea">
## 비즈니스 로직 로그 기능
컨트롤러, 서비스, 레퍼지토리 에서 어떤 메서드가 실행되었는지 로그로 남습니다.
<img width="1712" alt="image" src="https://github.com/Crew-Wiki/backend/assets/45223837/25244030-9ab7-4c74-9d0d-4d0fe85d9a80">
## 실행된 SQL 로그 기능
실행된 SQL 문이 로그로 남습니다.
<img width="898" alt="image" src="https://github.com/Crew-Wiki/backend/assets/45223837/c956acc5-11e9-4f5d-acba-73d45132fa7a">
## HTTP 응답 로그 기능
사용자에게 응답된 HTTP 응답의 헤더, 바디가 모두 파싱되어 로그로 남습니다.
<img width="1327" alt="image" src="https://github.com/Crew-Wiki/backend/assets/45223837/2f1dd5e7-b021-48e8-a4c3-fe3c34a538c6">

