### PR TITLE
[BE][FEAT] 어드민 로그인 API 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,8 @@ dependencies {
 
     implementation "org.jetbrains.kotlin:kotlin-reflect"
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
+
+    testImplementation 'io.rest-assured:rest-assured:5.3.1'
 }
 
 kapt {

--- a/src/main/java/com/wooteco/wiki/controller/AdminController.java
+++ b/src/main/java/com/wooteco/wiki/controller/AdminController.java
@@ -1,0 +1,63 @@
+package com.wooteco.wiki.controller;
+
+import com.wooteco.wiki.dto.AdminResponse;
+import com.wooteco.wiki.dto.LoginRequest;
+import com.wooteco.wiki.dto.TokenResponse;
+import com.wooteco.wiki.service.AuthService;
+import java.time.Duration;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.CookieValue;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class AdminController {
+
+    private static final String TOKEN_NAME_FIELD = "token";
+    private final AuthService authService;
+
+    public AdminController(AuthService authService) {
+        this.authService = authService;
+    }
+
+    @PostMapping("/login")
+    public ResponseEntity<Void> login(@RequestBody LoginRequest loginRequest) {
+        TokenResponse tokenResponse = authService.login(loginRequest);
+        ResponseCookie cookie = ResponseCookie
+                .from(TOKEN_NAME_FIELD, tokenResponse.accessToken())
+                .path("/")
+                .httpOnly(true)
+                .secure(false)
+                .maxAge(Duration.ofDays(30))
+                .sameSite("Lax")
+                .build();
+        return ResponseEntity.ok().header(HttpHeaders.SET_COOKIE, cookie.toString()).build();
+    }
+
+    @GetMapping("/login/check")
+    public ResponseEntity<AdminResponse> checkAuth(@CookieValue(name = TOKEN_NAME_FIELD) String token) {
+        AdminResponse adminResponse = authService.findMemberByToken(token);
+        return ResponseEntity.ok().body(adminResponse);
+    }
+
+    @PostMapping("/logout")
+    public ResponseEntity<Void> logout(@CookieValue(name = TOKEN_NAME_FIELD) String token) {
+        authService.findMemberByToken(token);
+
+        ResponseCookie cookie = ResponseCookie
+                .from(TOKEN_NAME_FIELD, "")
+                .domain("localhost")
+                .path("/")
+                .httpOnly(true)
+                .secure(true)
+                .maxAge(Duration.ofDays(0))
+                .sameSite("Strict")
+                .build();
+
+        return ResponseEntity.ok().header(HttpHeaders.SET_COOKIE, cookie.toString()).build();
+    }
+}

--- a/src/main/java/com/wooteco/wiki/domain/Admin.java
+++ b/src/main/java/com/wooteco/wiki/domain/Admin.java
@@ -1,0 +1,26 @@
+package com.wooteco.wiki.domain;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.Getter;
+
+@Entity
+public class Admin {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    @Getter
+    private String loginId;
+    @Getter
+    private String password;
+
+    protected Admin() {
+    }
+
+    public Admin(String loginId, String password) {
+        this.loginId = loginId;
+        this.password = password;
+    }
+}

--- a/src/main/java/com/wooteco/wiki/domain/Admin.java
+++ b/src/main/java/com/wooteco/wiki/domain/Admin.java
@@ -7,13 +7,12 @@ import jakarta.persistence.Id;
 import lombok.Getter;
 
 @Entity
+@Getter
 public class Admin {
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
-    @Getter
     private String loginId;
-    @Getter
     private String password;
 
     protected Admin() {

--- a/src/main/java/com/wooteco/wiki/domain/TokenManager.java
+++ b/src/main/java/com/wooteco/wiki/domain/TokenManager.java
@@ -1,93 +1,93 @@
-package com.wooteco.wiki.domain;
-
-import com.wooteco.wiki.exception.WrongTokenException;
-import io.jsonwebtoken.Claims;
-import io.jsonwebtoken.Jws;
-import io.jsonwebtoken.JwtException;
-import io.jsonwebtoken.Jwts;
-import io.jsonwebtoken.security.Keys;
-import java.time.Instant;
-import java.time.LocalDateTime;
-import java.time.ZoneId;
-import java.util.Date;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.stereotype.Component;
-
-@Component
-public class TokenManager {
-    private static final String MEMBER_ID = "member_id";
-    private static final String TOKEN_TYPE = "token_type";
-    private static final long ACCESS_TOKEN_LIFE_TIME_AS_HOUR = 1;
-    private static final long REFRESH_TOKEN_LIFE_TIME_AS_HOUR = 24;
-    @Value("${jwt.key}")
-    private String secretKey;
-
-    /**
-     * 생성된 엑세스 토큰은 리프레쉬 토큰으로 사용할 수 없어야 함. 엑세스 토큰에는 회원의 식별자를 제외한 다른 개인 정보가 포함되면 안됨. 우선 엑세스 토큰 유효 시간은 발급 시점으로부터 1시간으로 설정함.
-     * 논의 후 조정하기로!
-     *
-     * @param member 회원 도메인
-     * @return 엑세스 토큰
-     */
-    public String generateAccessToken(Member member) {
-        LocalDateTime rawExpiredTime = LocalDateTime.now().plusHours(ACCESS_TOKEN_LIFE_TIME_AS_HOUR);
-        Date expiredTime = localDateTimeToDate(rawExpiredTime);
-        return Jwts.builder()
-                .expiration(expiredTime)
-                .claim(TOKEN_TYPE, "access")
-                .claim(MEMBER_ID, member.getMemberId())
-                .signWith(Keys.hmacShaKeyFor(secretKey.getBytes()))
-                .compact();
-    }
-
-    private Date localDateTimeToDate(LocalDateTime expiredTime) {
-        Instant instant = expiredTime.atZone(ZoneId.systemDefault()).toInstant();
-        return Date.from(instant);
-    }
-
-    /**
-     * 생성된 리프레쉬 토큰은 엑세스 토큰으로 사용할 수 없어야 함. 우선 리프레쉬 토큰 유효 시간은 발급 시점으로부터 1일로 설정함. 논의 후 조정하기로!
-     *
-     * @param member 회원 도메인
-     * @return 리프레쉬 토큰
-     */
-    public String generateRefreshToken(Member member) {
-        LocalDateTime rawExpiredTime = LocalDateTime.now().plusHours(REFRESH_TOKEN_LIFE_TIME_AS_HOUR);
-        Date expiredTime = localDateTimeToDate(rawExpiredTime);
-        return Jwts.builder()
-                .expiration(expiredTime)
-                .claim(TOKEN_TYPE, "refresh")
-                .claim(MEMBER_ID, member.getMemberId())
-                .signWith(Keys.hmacShaKeyFor(secretKey.getBytes()))
-                .compact();
-    }
-
-    /**
-     * 회원 정보로부터 회원의 식별자를 알아냄.
-     *
-     * @param accessToken 엑세스 토큰
-     * @return 회원의 식별자.
-     * @throws WrongTokenException 엑세스 토큰에 문제(잘못된 토큰, 기간 만료 등)가 있어 회원 식별자를 추출할 수 없는 경우
-     */
-    public long extractMemberId(String accessToken) throws WrongTokenException {
-        try {
-            Jws<Claims> claimsJws = Jwts.parser()
-                    .verifyWith(Keys.hmacShaKeyFor(secretKey.getBytes()))
-                    .build()
-                    .parseSignedClaims(accessToken);
-
-            Claims payload = claimsJws.getPayload();
-            validateTokenIsAccessToken(payload);
-            return payload.get(MEMBER_ID, Long.class);
-        } catch (JwtException | IllegalArgumentException e) {
-            throw new WrongTokenException("잘못된 토큰입니다.");
-        }
-    }
-
-    private static void validateTokenIsAccessToken(Claims payload) {
-        String tokenType = payload.get(TOKEN_TYPE, String.class);
-        if (!tokenType.equals("access")) {
-            throw new WrongTokenException("엑세스 토큰이 아닙니다.");
-        }
-    }
-}
+//package com.wooteco.wiki.domain;
+//
+//import com.wooteco.wiki.exception.WrongTokenException;
+//import io.jsonwebtoken.Claims;
+//import io.jsonwebtoken.Jws;
+//import io.jsonwebtoken.JwtException;
+//import io.jsonwebtoken.Jwts;
+//import io.jsonwebtoken.security.Keys;
+//import java.time.Instant;
+//import java.time.LocalDateTime;
+//import java.time.ZoneId;
+//import java.util.Date;
+//import org.springframework.beans.factory.annotation.Value;
+//import org.springframework.stereotype.Component;
+//
+//@Component
+//public class TokenManager {
+//    private static final String MEMBER_ID = "member_id";
+//    private static final String TOKEN_TYPE = "token_type";
+//    private static final long ACCESS_TOKEN_LIFE_TIME_AS_HOUR = 1;
+//    private static final long REFRESH_TOKEN_LIFE_TIME_AS_HOUR = 24;
+//    @Value("${jwt.key}")
+//    private String secretKey;
+//
+//    /**
+//     * 생성된 엑세스 토큰은 리프레쉬 토큰으로 사용할 수 없어야 함. 엑세스 토큰에는 회원의 식별자를 제외한 다른 개인 정보가 포함되면 안됨. 우선 엑세스 토큰 유효 시간은 발급 시점으로부터 1시간으로 설정함.
+//     * 논의 후 조정하기로!
+//     *
+//     * @param member 회원 도메인
+//     * @return 엑세스 토큰
+//     */
+//    public String generateAccessToken(Member member) {
+//        LocalDateTime rawExpiredTime = LocalDateTime.now().plusHours(ACCESS_TOKEN_LIFE_TIME_AS_HOUR);
+//        Date expiredTime = localDateTimeToDate(rawExpiredTime);
+//        return Jwts.builder()
+//                .expiration(expiredTime)
+//                .claim(TOKEN_TYPE, "access")
+//                .claim(MEMBER_ID, member.getMemberId())
+//                .signWith(Keys.hmacShaKeyFor(secretKey.getBytes()))
+//                .compact();
+//    }
+//
+//    private Date localDateTimeToDate(LocalDateTime expiredTime) {
+//        Instant instant = expiredTime.atZone(ZoneId.systemDefault()).toInstant();
+//        return Date.from(instant);
+//    }
+//
+//    /**
+//     * 생성된 리프레쉬 토큰은 엑세스 토큰으로 사용할 수 없어야 함. 우선 리프레쉬 토큰 유효 시간은 발급 시점으로부터 1일로 설정함. 논의 후 조정하기로!
+//     *
+//     * @param member 회원 도메인
+//     * @return 리프레쉬 토큰
+//     */
+//    public String generateRefreshToken(Member member) {
+//        LocalDateTime rawExpiredTime = LocalDateTime.now().plusHours(REFRESH_TOKEN_LIFE_TIME_AS_HOUR);
+//        Date expiredTime = localDateTimeToDate(rawExpiredTime);
+//        return Jwts.builder()
+//                .expiration(expiredTime)
+//                .claim(TOKEN_TYPE, "refresh")
+//                .claim(MEMBER_ID, member.getMemberId())
+//                .signWith(Keys.hmacShaKeyFor(secretKey.getBytes()))
+//                .compact();
+//    }
+//
+//    /**
+//     * 회원 정보로부터 회원의 식별자를 알아냄.
+//     *
+//     * @param accessToken 엑세스 토큰
+//     * @return 회원의 식별자.
+//     * @throws WrongTokenException 엑세스 토큰에 문제(잘못된 토큰, 기간 만료 등)가 있어 회원 식별자를 추출할 수 없는 경우
+//     */
+//    public long extractMemberId(String accessToken) throws WrongTokenException {
+//        try {
+//            Jws<Claims> claimsJws = Jwts.parser()
+//                    .verifyWith(Keys.hmacShaKeyFor(secretKey.getBytes()))
+//                    .build()
+//                    .parseSignedClaims(accessToken);
+//
+//            Claims payload = claimsJws.getPayload();
+//            validateTokenIsAccessToken(payload);
+//            return payload.get(MEMBER_ID, Long.class);
+//        } catch (JwtException | IllegalArgumentException e) {
+//            throw new WrongTokenException("잘못된 토큰입니다.");
+//        }
+//    }
+//
+//    private static void validateTokenIsAccessToken(Claims payload) {
+//        String tokenType = payload.get(TOKEN_TYPE, String.class);
+//        if (!tokenType.equals("access")) {
+//            throw new WrongTokenException("엑세스 토큰이 아닙니다.");
+//        }
+//    }
+//}

--- a/src/main/java/com/wooteco/wiki/dto/AdminResponse.java
+++ b/src/main/java/com/wooteco/wiki/dto/AdminResponse.java
@@ -1,0 +1,10 @@
+package com.wooteco.wiki.dto;
+
+import com.wooteco.wiki.domain.Admin;
+
+public record AdminResponse() {
+
+    public static AdminResponse of(Admin admin) {
+        return null;
+    }
+}

--- a/src/main/java/com/wooteco/wiki/dto/LoginRequest.java
+++ b/src/main/java/com/wooteco/wiki/dto/LoginRequest.java
@@ -1,4 +1,4 @@
 package com.wooteco.wiki.dto;
 
-public record LoginRequest(String email, String password) {
+public record LoginRequest(String loginId, String password) {
 }

--- a/src/main/java/com/wooteco/wiki/dto/TokenInfoDto.java
+++ b/src/main/java/com/wooteco/wiki/dto/TokenInfoDto.java
@@ -1,0 +1,10 @@
+package com.wooteco.wiki.dto;
+
+import com.wooteco.wiki.domain.Admin;
+
+public record TokenInfoDto (Long id) {
+
+    public static TokenInfoDto of(Admin admin) {
+        return new TokenInfoDto(admin.getId());
+    }
+}

--- a/src/main/java/com/wooteco/wiki/dto/TokenResponse.java
+++ b/src/main/java/com/wooteco/wiki/dto/TokenResponse.java
@@ -1,0 +1,4 @@
+package com.wooteco.wiki.dto;
+
+public record TokenResponse(String accessToken) {
+}

--- a/src/main/java/com/wooteco/wiki/exception/NotFoundAdminException.java
+++ b/src/main/java/com/wooteco/wiki/exception/NotFoundAdminException.java
@@ -1,0 +1,16 @@
+package com.wooteco.wiki.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class NotFoundAdminException extends WikiException {
+
+    private static final String DEFAULT_MESSAGE = "해당 관리자를 찾을 수 없습니다";
+
+    public NotFoundAdminException(String message) {
+        super(message, HttpStatus.NOT_FOUND);
+    }
+
+    public NotFoundAdminException() {
+        this(DEFAULT_MESSAGE);
+    }
+}

--- a/src/main/java/com/wooteco/wiki/exception/TokenCreateException.java
+++ b/src/main/java/com/wooteco/wiki/exception/TokenCreateException.java
@@ -1,0 +1,16 @@
+package com.wooteco.wiki.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class TokenCreateException extends WikiException {
+
+    private static final String DEFAULT_MESSAGE_FILED = "토큰 생성에 실패했습니다.";
+
+    public TokenCreateException(String message) {
+        super(message, HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+
+    public TokenCreateException() {
+        this(DEFAULT_MESSAGE_FILED);
+    }
+}

--- a/src/main/java/com/wooteco/wiki/exception/WikiExceptionHandler.java
+++ b/src/main/java/com/wooteco/wiki/exception/WikiExceptionHandler.java
@@ -10,6 +10,7 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 @ControllerAdvice
 @Slf4j
 public class WikiExceptionHandler {
+
     @ExceptionHandler(WikiException.class)
     public ResponseEntity<ErrorResponse> handle(WikiException exception) {
         log.error(exception.getMessage(), exception);

--- a/src/main/java/com/wooteco/wiki/exception/WrongTokenException.java
+++ b/src/main/java/com/wooteco/wiki/exception/WrongTokenException.java
@@ -3,7 +3,14 @@ package com.wooteco.wiki.exception;
 import org.springframework.http.HttpStatus;
 
 public class WrongTokenException extends WikiException {
+
+    private static final String DEFAULT_MESSAGE_FILED = "잘못된 토큰입니다.";
+
     public WrongTokenException(String message) {
         super(message, HttpStatus.UNAUTHORIZED);
+    }
+
+    public WrongTokenException() {
+        this(DEFAULT_MESSAGE_FILED);
     }
 }

--- a/src/main/java/com/wooteco/wiki/global/auth/JwtTokenProvider.java
+++ b/src/main/java/com/wooteco/wiki/global/auth/JwtTokenProvider.java
@@ -1,0 +1,84 @@
+package com.wooteco.wiki.global.auth;
+
+import com.wooteco.wiki.dto.TokenInfoDto;
+import com.wooteco.wiki.exception.TokenCreateException;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import jakarta.annotation.PostConstruct;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+import javax.crypto.SecretKey;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+public class JwtTokenProvider {
+
+    @Value("${security.jwt.token.secret-key}")
+    private String strSecretKey;
+    @Value("${security.jwt.token.expire-length}")
+    private long validityInMilliseconds;
+
+    private SecretKey secretKey;
+
+    @PostConstruct
+    private void init() {
+        this.secretKey = Keys.hmacShaKeyFor(strSecretKey.getBytes());
+    }
+
+    public String createToken(TokenInfoDto tokenInfoDto) {
+
+        Map<String, ?> claims = getMyClaimMap(tokenInfoDto);
+
+        Date now = new Date();
+        Date validity = new Date(now.getTime() + validityInMilliseconds);
+        try {
+            return Jwts.builder()
+                    .subject(String.valueOf(tokenInfoDto.id()))
+                    .claims(claims)
+                    .issuedAt(now)
+                    .expiration(validity)
+                    .signWith(secretKey)
+                    .compact();
+        } catch (JwtException e) {
+            throw new TokenCreateException();
+        }
+    }
+
+    private Map<String, ?> getMyClaimMap(TokenInfoDto tokenInfoDto) {
+        Map<String, Object> map = new HashMap<>();
+        map.put("id", tokenInfoDto.id());
+
+        return new HashMap<>(map);
+    }
+
+    public String getPayload(String token) {
+        Claims claims = getClaims(token);
+        return claims.getSubject();
+    }
+
+    public Claims getClaims(String token) {
+        return Jwts.parser()
+                .verifyWith(secretKey)
+                .build()
+                .parseSignedClaims(token)
+                .getPayload();
+    }
+
+    public boolean validateToken(String token) {
+        try {
+            Claims claims = Jwts.parser()
+                    .verifyWith(secretKey)
+                    .build()
+                    .parseSignedClaims(token)
+                    .getPayload();
+
+            return !claims.getExpiration().before(new Date());
+        } catch (JwtException | IllegalArgumentException e) {
+            return false;
+        }
+    }
+}

--- a/src/main/java/com/wooteco/wiki/repository/AdminRepository.java
+++ b/src/main/java/com/wooteco/wiki/repository/AdminRepository.java
@@ -1,0 +1,10 @@
+package com.wooteco.wiki.repository;
+
+import com.wooteco.wiki.domain.Admin;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AdminRepository extends JpaRepository<Admin, Long> {
+
+    Optional<Admin> findOneByLoginIdAndPassword(String loginId, String password);
+}

--- a/src/main/java/com/wooteco/wiki/service/AuthService.java
+++ b/src/main/java/com/wooteco/wiki/service/AuthService.java
@@ -1,15 +1,50 @@
 package com.wooteco.wiki.service;
 
-import com.wooteco.wiki.dto.AuthTokens;
-import com.wooteco.wiki.dto.JoinRequest;
+import com.wooteco.wiki.domain.Admin;
+import com.wooteco.wiki.dto.AdminResponse;
 import com.wooteco.wiki.dto.LoginRequest;
+import com.wooteco.wiki.dto.TokenInfoDto;
+import com.wooteco.wiki.dto.TokenResponse;
+import com.wooteco.wiki.exception.NotFoundAdminException;
+import com.wooteco.wiki.exception.WrongTokenException;
+import com.wooteco.wiki.global.auth.JwtTokenProvider;
+import com.wooteco.wiki.repository.AdminRepository;
+import org.springframework.stereotype.Service;
 
+@Service
 public class AuthService {
-    public AuthTokens login(LoginRequest loginRequest) {
-        return null;
+
+    private final JwtTokenProvider jwtTokenProvider;
+    private final AdminRepository adminRepository;
+
+    public AuthService(JwtTokenProvider jwtTokenProvider, AdminRepository adminRepository) {
+        this.jwtTokenProvider = jwtTokenProvider;
+        this.adminRepository = adminRepository;
     }
 
-    public AuthTokens join(JoinRequest joinRequest) {
-        return null;
+    public TokenResponse login(LoginRequest loginRequest) {
+        Admin admin = adminRepository.findOneByLoginIdAndPassword(loginRequest.loginId(), loginRequest.password())
+                .orElseThrow(NotFoundAdminException::new);
+        return createToken(TokenInfoDto.of(admin));
+    }
+
+    public TokenResponse createToken(TokenInfoDto tokenInfoDto) {
+        String accessToken = jwtTokenProvider.createToken(tokenInfoDto);
+        return new TokenResponse(accessToken);
+    }
+
+    public AdminResponse findMemberByToken(String token) {
+        if (!jwtTokenProvider.validateToken(token)) {
+            throw new WrongTokenException();
+        }
+        String payload = jwtTokenProvider.getPayload(token);
+        Admin admin = findAdmin(payload);
+        return AdminResponse.of(admin);
+    }
+
+    public Admin findAdmin(String payload) {
+        Long id = Long.valueOf(payload);
+        return adminRepository.findById(id)
+                .orElseThrow(NotFoundAdminException::new);
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -21,5 +21,8 @@ spring:
         physical-strategy: org.hibernate.boot.model.naming.PhysicalNamingStrategyStandardImpl
     show-sql: true
 
-jwt:
-  key: 012345678901234567890123456789012345678901234567890123456789
+security:
+  jwt:
+    token:
+      secret-key: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIiLCJuYW1lIjoiSm9obiBEb2UiLCJpYXQiOjE1MTYyMzkwMjJ9.ih1aovtQShabQ7l0cINw4k1fagApg3qLWiB8Kt59Lno2
+      expire-length: 3600000

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -5,3 +5,6 @@ VALUES
     ('메이슨', 'JPA (Java Persistence API) is a powerful tool...', '토다리', 5120, '2024-03-11 08:45:00'),
     ('토다리', 'A well-designed REST API is easy to use...', '쿠키', 4096, '2024-03-10 14:20:00'),
     ('쿠키', 'Microservices architecture is a design approach...', '메이슨', 8192, '2024-03-09 11:10:00');
+
+INSERT INTO Admin(loginId, password)
+VALUES ('adminGood', 'helloWorld!!');

--- a/src/test/java/com/wooteco/wiki/controller/AdminControllerTest.java
+++ b/src/test/java/com/wooteco/wiki/controller/AdminControllerTest.java
@@ -1,0 +1,109 @@
+package com.wooteco.wiki.controller;
+
+import com.wooteco.wiki.domain.Admin;
+import com.wooteco.wiki.dto.LoginRequest;
+import com.wooteco.wiki.dto.TokenResponse;
+import com.wooteco.wiki.repository.AdminRepository;
+import com.wooteco.wiki.service.AuthService;
+import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.http.HttpStatus;
+import org.springframework.test.annotation.DirtiesContext;
+
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
+class AuthControllerTest {
+
+    private static final String TOKEN_NAME_FILED = "token";
+
+    @Autowired
+    private AuthService authService;
+    @Autowired
+    private AdminRepository adminRepository;
+
+    private Admin savedAdmin;
+
+    @LocalServerPort
+    int port;
+
+    @BeforeEach
+    void setUp() {
+        RestAssured.port = port;
+        savedAdmin = adminRepository.save(new Admin("admin", "password"));
+    }
+
+    @Nested
+    @DisplayName("로그인 기능")
+    class login {
+
+        @DisplayName("유효한 이메일과 비밀번호로 로그인을 성공한다.")
+        @Test
+        void login_success() {
+            // given
+
+            // when
+            LoginRequest requestDto = new LoginRequest(savedAdmin.getLoginId(), savedAdmin.getPassword());
+
+            // then
+            RestAssured
+                    .given().log().all()
+                    .contentType(ContentType.JSON)
+                    .body(requestDto)
+                    .when().post("/login")
+                    .then().log().all()
+                    .statusCode(HttpStatus.OK.value())
+                    .extract().response();
+        }
+
+        @DisplayName("유효하지 않는 이메일과 비밀번호로 로그인을 시도하여 실패: 상태 코드 404를 반환한다.")
+        @Test
+        void login_throwException_byInvalidEmail() {
+            // given
+            // when
+            LoginRequest requestDto = new LoginRequest("invalidLoginId", "invalidPassword");
+
+            // then
+            RestAssured
+                    .given().log().all()
+                    .contentType(ContentType.JSON)
+                    .body(requestDto)
+                    .when().post("/login")
+                    .then().log().all()
+                    .statusCode(HttpStatus.NOT_FOUND.value())
+                    .extract().response();
+        }
+    }
+
+    @Nested
+    @DisplayName("토큰 기반 어드민 조회 API 테스트")
+    class checkAuth {
+
+        @DisplayName("토큰으로 어드민 조회 시 200 OK 반환")
+        @Test
+        void checkAuth_success() {
+            // given
+            String expectedLoginId = "loginIdCS";
+            Admin savedAdmin = adminRepository.save(new Admin(expectedLoginId, "password"));
+            LoginRequest loginRequest = new LoginRequest(savedAdmin.getLoginId(), savedAdmin.getPassword());
+            TokenResponse responseDto = authService.login(loginRequest);
+            String token = responseDto.accessToken();
+
+            // when
+            // then
+            RestAssured
+                    .given().log().all()
+                    .cookie(TOKEN_NAME_FILED, token)
+                    .when().get("/login/check")
+                    .then().log().all()
+                    .statusCode(HttpStatus.OK.value());
+        }
+    }
+}

--- a/src/test/java/com/wooteco/wiki/repository/AdminRepositoryTest.java
+++ b/src/test/java/com/wooteco/wiki/repository/AdminRepositoryTest.java
@@ -1,0 +1,55 @@
+package com.wooteco.wiki.repository;
+
+import com.wooteco.wiki.domain.Admin;
+import java.util.Optional;
+import org.assertj.core.api.Assertions;
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+@DataJpaTest
+class AdminRepositoryTest {
+
+    @Autowired
+    private AdminRepository adminRepository;
+
+    @Nested
+    @DisplayName("loginId와 password로 Admin을 찾는 기능")
+    class findOneByLoginIdAndPassword {
+
+        @DisplayName("유효한 loginId와 password로 Admin을 반환한다.")
+        @Test
+        void findOneByLoginIdAndPassword_success_byValidLoginIdAndPassword() {
+            // given
+            Admin savedAdmin = adminRepository.save(new Admin("admin", "password"));
+
+            // when
+            Optional<Admin> adminOptional = adminRepository.findOneByLoginIdAndPassword(
+                    savedAdmin.getLoginId(), savedAdmin.getPassword());
+
+            // then
+            SoftAssertions.assertSoftly(softly -> {
+                softly.assertThat(adminOptional.isPresent()).isTrue();
+                softly.assertThat(adminOptional.get().getLoginId()).isEqualTo(savedAdmin.getLoginId());
+                softly.assertThat(adminOptional.get().getPassword()).isEqualTo(savedAdmin.getPassword());
+            });
+        }
+
+        @DisplayName("알맞지 않는 loginId와 password로 Optional.isEmpty를 반환한다.")
+        @Test
+        void findOneByLoginIdAndPassword_isEmpty_byInValidLoginIdAndPassword() {
+            // given
+            adminRepository.save(new Admin("admin", "password"));
+
+            // when
+            Optional<Admin> adminOptional = adminRepository.findOneByLoginIdAndPassword("invalidLoginId", "invalidPassword");
+
+            // then
+            Assertions.assertThat(adminOptional.isEmpty()).isTrue();
+        }
+    }
+
+}

--- a/src/test/java/com/wooteco/wiki/service/AuthServiceTest.java
+++ b/src/test/java/com/wooteco/wiki/service/AuthServiceTest.java
@@ -1,0 +1,81 @@
+package com.wooteco.wiki.service;
+
+import com.wooteco.wiki.domain.Admin;
+import com.wooteco.wiki.dto.LoginRequest;
+import com.wooteco.wiki.dto.TokenInfoDto;
+import com.wooteco.wiki.dto.TokenResponse;
+import com.wooteco.wiki.exception.NotFoundAdminException;
+import com.wooteco.wiki.global.auth.JwtTokenProvider;
+import com.wooteco.wiki.repository.AdminRepository;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+
+@DataJpaTest
+@Import({
+        AuthService.class,
+        JwtTokenProvider.class,
+})
+class AuthServiceTest {
+
+    @Autowired
+    private AuthService authService;
+    @Autowired
+    private AdminRepository adminRepository;
+
+    @Nested
+    @DisplayName("TokenInfoDto로 Jwt 토큰 생성")
+    class createToken {
+
+        @DisplayName("TokenInfoDto로 Jwt 토큰 생성된다.")
+        @Test
+        void createToken_success() {
+            // given
+            TokenInfoDto tokenInfoDto = new TokenInfoDto(1L);
+
+            // when
+            TokenResponse tokenResponse = authService.createToken(tokenInfoDto);
+
+            // then
+            org.assertj.core.api.Assertions.assertThat(tokenResponse).isNotNull();
+            System.out.println(tokenResponse);
+        }
+    }
+
+    @Nested
+    @DisplayName("loginRequest로 Jwt 토큰 생성")
+    class login {
+
+        @DisplayName("존재하는 어드민 정보로 요청했을 시 Jwt 토큰을 반환한다.")
+        @Test
+        void login_success_byExistingAdmin() {
+            // given
+            Admin savedAdmin = adminRepository.save(new Admin("admin", "password"));
+            LoginRequest loginRequest = new LoginRequest(savedAdmin.getLoginId(), savedAdmin.getPassword());
+
+            // when
+            TokenResponse tokenResponse = authService.login(loginRequest);
+
+            // then
+            org.assertj.core.api.Assertions.assertThat(tokenResponse).isNotNull();
+            System.out.println(tokenResponse);
+        }
+
+        @DisplayName("존재하지 않는 어드민 정보로 요쳥했을 때 예외 발생한다. : NotFoundAdminException")
+        @Test
+        void login_throwException_byInValidAdmin() {
+            // given
+            LoginRequest loginRequest = new LoginRequest("invalidLoginId", "invalidPassword");
+
+            // when
+            // then
+            Assertions.assertThatThrownBy(
+                    () -> authService.login(loginRequest)
+            ).isInstanceOf(NotFoundAdminException.class);
+        }
+    }
+}

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -1,0 +1,4 @@
+spring.h2.console.enabled=true
+spring.datasource.url=jdbc:h2:mem:database
+security.jwt.token.secret-key=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIiLCJuYW1lIjoiSm9obiBEb2UiLCJpYXQiOjE1MTYyMzkwMjJ9.ih1aovtQShabQ7l0cINw4k1fagApg3qLWiB8Kt59Lno2
+security.jwt.token.expire-length=3600000


### PR DESCRIPTION
- [X] 💯 테스트는 잘 통과했나요?
- [X] 🏗️ 빌드는 성공했나요?
- [X] 🧹 불필요한 코드는 제거했나요?
- [X] 💭 이슈는 등록했나요?
- [X] 🏷️ 라벨은 등록했나요?

## 작업 내용
- 어드민 로그인 API 기능 구현

<details>
<summary>세부 사항</summary>
<div markdown="1">

## 요구사항
- [x] 관리자 로그인 API 기능
	- [x] 요청
		- String: id
		- String: password
	- [x] 반환
		- (cookie) accessToken

## 기능 구현 사항
- [x] 관리자 엔티티 생성
	- id, password
- [x] 더미데이터 추가
- [x] API 작성


## 추가 처리 사항
- [ ] securityKey 같은 거 yml 파일에서 분리 어떻게 할 건지


## 보고 사항
-  토큰 생성 시 실패 에러: 500 Inteneral Error
	- 구현 코드 상의 오류가 아닌 서버 오류이기 때문
- 기본적으로 원래 있던 컨벤션을 따라 작성함
- Dto 내에서 도메인 참조해서 convert 과정 수행


## 제안하고 싶은 것
- 도메인 별로 패키지 분리
	- 지금 계층별 처리가 되어 있는데 보기 어려움
- Dto에는 클래스명 뒤에 Dto 추가하기

</div>
</details>


## 스크린샷

![image](https://github.com/user-attachments/assets/5c6d09ec-f317-443c-8d68-c3d6e522d7d0)


## 주의사항
없음

Closes #26 