### PR TITLE
feat(DocumentSearch): 검색시, 문서 제목과 UUID 같이 바인딩하여 반환

### DIFF
--- a/src/main/java/com/wooteco/wiki/document/controller/DocumentController.kt
+++ b/src/main/java/com/wooteco/wiki/document/controller/DocumentController.kt
@@ -1,10 +1,7 @@
 package com.wooteco.wiki.document.controller
 
 import com.wooteco.wiki.document.domain.Document
-import com.wooteco.wiki.document.domain.dto.DocumentCreateRequest
-import com.wooteco.wiki.document.domain.dto.DocumentResponse
-import com.wooteco.wiki.document.domain.dto.DocumentUpdateRequest
-import com.wooteco.wiki.document.domain.dto.DocumentUuidResponse
+import com.wooteco.wiki.document.domain.dto.*
 import com.wooteco.wiki.document.service.DocumentSearchService
 import com.wooteco.wiki.document.service.DocumentService
 import com.wooteco.wiki.document.service.UUIDService
@@ -89,7 +86,7 @@ class DocumentController(
     }
 
     @GetMapping("/search")
-    fun search(@RequestParam keyWord: String): List<String> {
+    fun search(@RequestParam keyWord: String): List<DocumentSearchResponse> {
         return documentSearchService.search(keyWord)
     }
 

--- a/src/main/java/com/wooteco/wiki/document/domain/dto/DocumentSearchResponse.kt
+++ b/src/main/java/com/wooteco/wiki/document/domain/dto/DocumentSearchResponse.kt
@@ -1,0 +1,8 @@
+package com.wooteco.wiki.document.domain.dto
+
+import java.util.*
+
+data class DocumentSearchResponse(
+    val title: String,
+    val uuid: UUID,
+)

--- a/src/main/java/com/wooteco/wiki/document/repository/DocumentRepository.java
+++ b/src/main/java/com/wooteco/wiki/document/repository/DocumentRepository.java
@@ -1,7 +1,6 @@
 package com.wooteco.wiki.document.repository;
 
 import com.wooteco.wiki.document.domain.Document;
-import com.wooteco.wiki.document.domain.Title;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -15,10 +14,10 @@ public interface DocumentRepository extends JpaRepository<Document, Long> {
 
     Boolean existsByTitle(String title);
 
-    List<Title> findAllByTitleStartingWith(String keyWord);
+    List<Document> findAllByTitleStartingWith(String keyWord);
 
     Optional<Document> findByUuid(UUID uuid);
 
     @Query("SELECT d.uuid FROM Document d WHERE d.title = :title")
-    Optional<UUID> findUuidByTitle(@Param("title")String title);
+    Optional<UUID> findUuidByTitle(@Param("title") String title);
 }

--- a/src/main/java/com/wooteco/wiki/document/service/DocumentSearchService.kt
+++ b/src/main/java/com/wooteco/wiki/document/service/DocumentSearchService.kt
@@ -11,6 +11,7 @@ class DocumentSearchService(
     private val documentRepository: DocumentRepository,
 ) {
 
+    @Transactional(readOnly = true)
     fun search(keyWord: String): List<DocumentSearchResponse> =
         documentRepository.findAllByTitleStartingWith(keyWord)
             .map { DocumentSearchResponse(it.title, it.uuid) }

--- a/src/main/java/com/wooteco/wiki/document/service/DocumentSearchService.kt
+++ b/src/main/java/com/wooteco/wiki/document/service/DocumentSearchService.kt
@@ -13,5 +13,5 @@ class DocumentSearchService(
 
     fun search(keyWord: String): List<DocumentSearchResponse> =
         documentRepository.findAllByTitleStartingWith(keyWord)
-            .map { DocumentSearchResponse(it.title, it.uuid) };
+            .map { DocumentSearchResponse(it.title, it.uuid) }
 }

--- a/src/main/java/com/wooteco/wiki/document/service/DocumentSearchService.kt
+++ b/src/main/java/com/wooteco/wiki/document/service/DocumentSearchService.kt
@@ -1,5 +1,6 @@
 package com.wooteco.wiki.document.service
 
+import com.wooteco.wiki.document.domain.dto.DocumentSearchResponse
 import com.wooteco.wiki.document.repository.DocumentRepository
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -10,7 +11,7 @@ class DocumentSearchService(
     private val documentRepository: DocumentRepository,
 ) {
 
-    fun search(keyWord: String): List<String> =
+    fun search(keyWord: String): List<DocumentSearchResponse> =
         documentRepository.findAllByTitleStartingWith(keyWord)
-            .map { it.title }
+            .map { DocumentSearchResponse(it.title, it.uuid) };
 }

--- a/src/test/java/com/wooteco/wiki/document/service/DocumentSearchServiceTest.java
+++ b/src/test/java/com/wooteco/wiki/document/service/DocumentSearchServiceTest.java
@@ -1,0 +1,56 @@
+package com.wooteco.wiki.document.service;
+
+import com.wooteco.wiki.document.domain.dto.DocumentSearchResponse;
+import com.wooteco.wiki.document.fixture.DocumentFixture;
+import com.wooteco.wiki.document.repository.DocumentRepository;
+import java.util.List;
+import java.util.UUID;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
+class DocumentSearchServiceTest {
+
+    @Autowired
+    private DocumentSearchService documentSearchService;
+
+    @Autowired
+    private DocumentRepository documentRepository;
+
+    @Autowired
+    private DocumentService documentService;
+
+    @DisplayName("검색어로 시작하는 문서들을 찾아 리스트로 반환한다.")
+    @Test
+    void search_success() {
+        // given
+        documentService.post(
+                DocumentFixture.createDocumentCreateRequest("title1", "content1", "writer1", 10L, UUID.randomUUID()));
+        documentService.post(
+                DocumentFixture.createDocumentCreateRequest("title2", "content2", "writer2", 11L, UUID.randomUUID()));
+
+        // when
+        List<DocumentSearchResponse> result = documentSearchService.search("title");
+
+        // then
+        Assertions.assertThat(result).hasSize(2);
+    }
+
+    @DisplayName("검색어와 일치하는 문서가 없으면 빈 리스트를 반환한다.")
+    @Test
+    void search_empty() {
+        // given
+        String keyword = "존재하지않는문서";
+
+        // when
+        List<DocumentSearchResponse> result = documentSearchService.search(keyword);
+
+        // then
+        Assertions.assertThat(result).isEmpty();
+    }
+} 


### PR DESCRIPTION
- [X] 💯 테스트는 잘 통과했나요?
- [X]  🏗️ 빌드는 성공했나요?
- [X]  🧹 불필요한 코드는 제거했나요?
- [X]  💭 이슈는 등록했나요?
- [X]  🏷️ 라벨은 등록했나요?

## 작업 내용
문서 검색 기능에 UUID 추가

## 세부 사항
- 기존에 title만 반환하던 것을 UUID로 묶은 DTO로 반환

<br>

- init.sql 추가
- document 엔티티 내에 id 필드명 수정(documentId -> id)

## 스크린 샷
<img width="1302" alt="image" src="https://github.com/user-attachments/assets/3760fd09-ba48-49b2-92bd-42dd31a10915" />
<br>

## 주의사항
기존에 검색할 때, Repo에서 Title만 가져왔는데, 이에 대한 성능 이슈가 생길 것인지 ?

Closes #45 