### PR TITLE
[FEAT] 어드민, 문서 삭제 API 구현

### DIFF
--- a/src/main/java/com/wooteco/wiki/admin/controller/AdminController.java
+++ b/src/main/java/com/wooteco/wiki/admin/controller/AdminController.java
@@ -2,6 +2,7 @@ package com.wooteco.wiki.admin.controller;
 
 import com.wooteco.wiki.admin.domain.dto.AdminResponse;
 import com.wooteco.wiki.admin.domain.dto.LoginRequest;
+import com.wooteco.wiki.admin.service.AdminService;
 import com.wooteco.wiki.global.auth.domain.dto.TokenResponse;
 import com.wooteco.wiki.global.auth.service.AuthService;
 import java.time.Duration;
@@ -9,7 +10,9 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.CookieValue;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -21,9 +24,11 @@ public class AdminController {
 
     private static final String TOKEN_NAME_FIELD = "token";
     private final AuthService authService;
+    private final AdminService adminService;
 
-    public AdminController(AuthService authService) {
+    public AdminController(AuthService authService, AdminService adminService) {
         this.authService = authService;
+        this.adminService = adminService;
     }
 
     @PostMapping("/login")
@@ -61,5 +66,11 @@ public class AdminController {
                 .build();
 
         return ResponseEntity.ok().header(HttpHeaders.SET_COOKIE, cookie.toString()).build();
+    }
+
+    @DeleteMapping("/documents/{documentId}")
+    public ResponseEntity<Void> deleteDocumentByDocumentId(@PathVariable Long documentId) {
+        adminService.deleteDocumentByDocumentId(documentId);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/wooteco/wiki/admin/service/AdminService.java
+++ b/src/main/java/com/wooteco/wiki/admin/service/AdminService.java
@@ -1,0 +1,18 @@
+package com.wooteco.wiki.admin.service;
+
+import com.wooteco.wiki.document.service.DocumentService;
+import org.springframework.stereotype.Service;
+
+@Service
+public class AdminService {
+
+    private final DocumentService documentService;
+
+    public AdminService(DocumentService documentService) {
+        this.documentService = documentService;
+    }
+
+    public void deleteDocumentByDocumentId(Long documentId) {
+        documentService.deleteById(documentId);
+    }
+}

--- a/src/main/java/com/wooteco/wiki/document/service/DocumentService.kt
+++ b/src/main/java/com/wooteco/wiki/document/service/DocumentService.kt
@@ -54,8 +54,8 @@ class DocumentService(
     }
 
     fun findAll(requestDto: PageRequestDto): Page<Document> {
-            val pageable = requestDto.toPageable()
-            return documentRepository.findAll(pageable)
+        val pageable = requestDto.toPageable()
+        return documentRepository.findAll(pageable)
     }
 
     fun get(title: String): DocumentResponse =
@@ -82,10 +82,22 @@ class DocumentService(
 
         val updateData = document.update(title, contents, writer, documentBytes, LocalDateTime.now())
 
-        val log = Log(updateData.title, updateData.contents, updateData.writer, updateData.documentBytes, updateData.generateTime)
+        val log = Log(
+            updateData.title,
+            updateData.contents,
+            updateData.writer,
+            updateData.documentBytes,
+            updateData.generateTime
+        )
         logRepository.save(log)
 
         return mapToResponse(document)
+    }
+
+    fun deleteById(id: Long) {
+        documentRepository.findById(id)
+            .orElseThrow{DocumentNotFoundException()}
+        documentRepository.deleteById(id)
     }
 
     private fun mapToResponse(document: Document): DocumentResponse =

--- a/src/test/java/com/wooteco/wiki/document/service/DocumentServiceTest.java
+++ b/src/test/java/com/wooteco/wiki/document/service/DocumentServiceTest.java
@@ -6,6 +6,7 @@ import com.wooteco.wiki.document.domain.dto.DocumentResponse;
 import com.wooteco.wiki.document.domain.dto.DocumentUuidResponse;
 import com.wooteco.wiki.document.exception.DocumentNotFoundException;
 import com.wooteco.wiki.document.fixture.DocumentFixture;
+import com.wooteco.wiki.document.repository.DocumentRepository;
 import com.wooteco.wiki.global.common.PageRequestDto;
 import com.wooteco.wiki.global.exception.PageBadRequestException;
 import java.util.List;
@@ -28,6 +29,8 @@ class DocumentServiceTest {
 
     @Autowired
     private DocumentService documentService;
+    @Autowired
+    private DocumentRepository documentRepository;
 
     @Nested
     @DisplayName("문서 제목으로 조회하면 UUID를 반환하는 기능")
@@ -121,7 +124,6 @@ class DocumentServiceTest {
                 );
             }
 
-
             @DisplayName("PageRequestDto의 default 값으로 동작하는 지 확인")
             @Test
             void findAll_success_byPageRequestDtoDefault() {
@@ -185,6 +187,36 @@ class DocumentServiceTest {
                         () -> documentService.findAll(pageRequestDto)
                 ).isInstanceOf(PageBadRequestException.class);
             }
+        }
+    }
+    
+    @Nested
+    @DisplayName("문서 id로 삭제 기능")
+    class deleteById {
+        
+        @DisplayName("존재하는 문서 id일 경우 문서가 삭제 된다")
+        @Test
+        void deleteById_success_byExistsId() {
+            // given
+            DocumentResponse documentResponse = documentService.post(DocumentFixture.createDocumentCreateRequest("title1", "content1", "writer1", 10L, UUID.randomUUID()));
+
+            // before then
+            Assertions.assertThat(documentRepository.findAll()).hasSize(1);
+
+            // when
+            documentService.deleteById(documentResponse.getDocumentId());
+
+            // after then
+            Assertions.assertThat(documentRepository.findAll()).hasSize(0);
+        }
+
+        @DisplayName("존재하지 않는 문서의 id일 경우 예외가 발생한다 : DocumentNotFoundException")
+        @Test
+        void deleteById_throwsException_byNonExistsId() {
+            // when & then
+            Assertions.assertThatThrownBy(
+                    () -> documentService.deleteById(Long.MAX_VALUE)
+            ).isInstanceOf(DocumentNotFoundException.class);
         }
     }
 }


### PR DESCRIPTION
- [X] 💯 테스트는 잘 통과했나요?
- [X]  🏗️ 빌드는 성공했나요?
- [X]  🧹 불필요한 코드는 제거했나요?
- [X]  💭 이슈는 등록했나요?
- [X]  🏷️ 라벨은 등록했나요?

## 작업 내용
- 어드민, 문서 삭제 API 구현

## 세부 사항
- endPoint: `admin/documents/{documentId}`
- 요청 문서 id가 없을 시 예외 발생
    - `DocumentNotFoundException`
    - 프론트 측에서 요청을 잘못 보냈을 때 확인이 편할 것 같아 예외 처리함

<br>

## 스크린 샷
![image](https://github.com/user-attachments/assets/4c62b586-f83e-4c85-a7b4-cc3a5e5a2bd1)


<br>

## 주의사항
없음

Closes #51