### PR TITLE
[FEAT] 기존 조직 문서를 조직 문서에 연결하는 기능

### DIFF
--- a/src/main/java/com/wooteco/wiki/organizationdocument/controller/OrganizationDocumentController.java
+++ b/src/main/java/com/wooteco/wiki/organizationdocument/controller/OrganizationDocumentController.java
@@ -4,6 +4,7 @@ import com.wooteco.wiki.global.common.ApiResponse;
 import com.wooteco.wiki.global.common.ApiResponse.SuccessBody;
 import com.wooteco.wiki.global.common.ApiResponseGenerator;
 import com.wooteco.wiki.organizationdocument.dto.request.OrganizationDocumentCreateRequest;
+import com.wooteco.wiki.organizationdocument.dto.request.OrganizationDocumentLinkRequest;
 import com.wooteco.wiki.organizationdocument.dto.request.OrganizationDocumentUpdateRequest;
 import com.wooteco.wiki.organizationdocument.dto.response.OrganizationDocumentAndEventResponse;
 import com.wooteco.wiki.organizationdocument.dto.response.OrganizationDocumentResponse;
@@ -38,6 +39,16 @@ public class OrganizationDocumentController {
             @RequestBody OrganizationDocumentCreateRequest organizationDocumentCreateRequest) {
         OrganizationDocumentResponse organizationDocumentResponse = organizationDocumentService.create(
                 organizationDocumentCreateRequest);
+
+        return ApiResponseGenerator.success(organizationDocumentResponse);
+    }
+
+    @Operation(summary = "기존 조직 문서를 크루 문서에 연결", description = "이미 존재하는 조직 문서를 크루 문서와 연결합니다.")
+    @PostMapping("/link")
+    public ApiResponse<SuccessBody<OrganizationDocumentResponse>> linkOrganizationDocument(
+            @RequestBody OrganizationDocumentLinkRequest organizationDocumentLinkRequest) {
+        OrganizationDocumentResponse organizationDocumentResponse = organizationDocumentService.link(
+                organizationDocumentLinkRequest);
 
         return ApiResponseGenerator.success(organizationDocumentResponse);
     }

--- a/src/main/java/com/wooteco/wiki/organizationdocument/dto/request/OrganizationDocumentLinkRequest.java
+++ b/src/main/java/com/wooteco/wiki/organizationdocument/dto/request/OrganizationDocumentLinkRequest.java
@@ -1,0 +1,9 @@
+package com.wooteco.wiki.organizationdocument.dto.request;
+
+import java.util.UUID;
+
+public record OrganizationDocumentLinkRequest(
+        UUID crewDocumentUuid,
+        UUID organizationDocumentUuid
+) {
+}

--- a/src/main/java/com/wooteco/wiki/organizationdocument/service/OrganizationDocumentService.java
+++ b/src/main/java/com/wooteco/wiki/organizationdocument/service/OrganizationDocumentService.java
@@ -10,6 +10,7 @@ import com.wooteco.wiki.global.exception.WikiException;
 import com.wooteco.wiki.history.service.HistoryService;
 import com.wooteco.wiki.organizationdocument.domain.OrganizationDocument;
 import com.wooteco.wiki.organizationdocument.dto.request.OrganizationDocumentCreateRequest;
+import com.wooteco.wiki.organizationdocument.dto.request.OrganizationDocumentLinkRequest;
 import com.wooteco.wiki.organizationdocument.dto.request.OrganizationDocumentUpdateRequest;
 import com.wooteco.wiki.organizationdocument.dto.response.OrganizationDocumentAndEventResponse;
 import com.wooteco.wiki.organizationdocument.dto.response.OrganizationDocumentResponse;
@@ -45,6 +46,14 @@ public class OrganizationDocumentService {
         historyService.save(savedOrganizationDocument);
         documentOrganizationLinkService.link(crewDocument, savedOrganizationDocument);
         return new OrganizationDocumentResponse(savedOrganizationDocument);
+    }
+
+    public OrganizationDocumentResponse link(OrganizationDocumentLinkRequest organizationDocumentLinkRequest) {
+        CrewDocument crewDocument = getCrewDocument(organizationDocumentLinkRequest.crewDocumentUuid());
+        OrganizationDocument organizationDocument = getOrganizationDocument(
+                organizationDocumentLinkRequest.organizationDocumentUuid());
+        documentOrganizationLinkService.link(crewDocument, organizationDocument);
+        return new OrganizationDocumentResponse(organizationDocument);
     }
 
     public OrganizationDocumentResponse update(OrganizationDocumentUpdateRequest organizationDocumentUpdateRequest) {

--- a/src/test/java/com/wooteco/wiki/organizationdocument/service/OrganizationDocumentServiceTest.java
+++ b/src/test/java/com/wooteco/wiki/organizationdocument/service/OrganizationDocumentServiceTest.java
@@ -1,0 +1,108 @@
+package com.wooteco.wiki.organizationdocument.service;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+
+import com.wooteco.wiki.document.domain.CrewDocument;
+import com.wooteco.wiki.document.fixture.CrewDocumentFixture;
+import com.wooteco.wiki.document.repository.CrewDocumentRepository;
+import com.wooteco.wiki.global.exception.WikiException;
+import com.wooteco.wiki.organizationdocument.domain.DocumentOrganizationLink;
+import com.wooteco.wiki.organizationdocument.domain.OrganizationDocument;
+import com.wooteco.wiki.organizationdocument.dto.request.OrganizationDocumentLinkRequest;
+import com.wooteco.wiki.organizationdocument.fixture.OrganizationDocumentFixture;
+import com.wooteco.wiki.organizationdocument.repository.DocumentOrganizationLinkRepository;
+import com.wooteco.wiki.organizationdocument.repository.OrganizationDocumentRepository;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
+class OrganizationDocumentServiceTest {
+
+    @Autowired
+    private OrganizationDocumentService organizationDocumentService;
+
+    @Autowired
+    private CrewDocumentRepository crewDocumentRepository;
+
+    @Autowired
+    private OrganizationDocumentRepository organizationDocumentRepository;
+
+    @Autowired
+    private DocumentOrganizationLinkRepository documentOrganizationLinkRepository;
+
+    @DisplayName("기존 조직 문서를 크루 문서에 연결할 때")
+    @Nested
+    class LinkExistingOrganization {
+
+        private CrewDocument savedCrewDocument;
+        private OrganizationDocument savedOrganizationDocument;
+
+        @BeforeEach
+        void setUp() {
+            CrewDocument crewDocument = CrewDocumentFixture.createDefaultCrewDocument();
+            savedCrewDocument = crewDocumentRepository.save(crewDocument);
+
+            OrganizationDocument organizationDocument = OrganizationDocumentFixture.createDefault();
+            savedOrganizationDocument = organizationDocumentRepository.save(organizationDocument);
+        }
+
+        @DisplayName("성공적으로 기존 조직 문서를 크루 문서와 연결한다")
+        @Test
+        void link_success() {
+            // given
+            OrganizationDocumentLinkRequest request = new OrganizationDocumentLinkRequest(
+                savedCrewDocument.getUuid(),
+                savedOrganizationDocument.getUuid()
+            );
+
+            // when
+            organizationDocumentService.link(request);
+
+            // then
+            DocumentOrganizationLink link = documentOrganizationLinkRepository
+                .findByCrewDocumentAndOrganizationDocument(savedCrewDocument, savedOrganizationDocument)
+                .orElseThrow();
+
+            assertSoftly(softly -> {
+                softly.assertThat(link.getCrewDocument().getId()).isEqualTo(savedCrewDocument.getId());
+                softly.assertThat(link.getOrganizationDocument().getId()).isEqualTo(savedOrganizationDocument.getId());
+            });
+        }
+
+        @DisplayName("존재하지 않는 크루 문서 UUID로 연결을 시도하면 예외가 발생한다")
+        @Test
+        void link_fail_crewDocumentNotFound() {
+            // given
+            OrganizationDocumentLinkRequest request = new OrganizationDocumentLinkRequest(
+                UUID.randomUUID(),
+                savedOrganizationDocument.getUuid()
+            );
+
+            // when & then
+            assertThatThrownBy(() -> organizationDocumentService.link(request))
+                .isInstanceOf(WikiException.class);
+        }
+
+        @DisplayName("존재하지 않는 조직 문서 UUID로 연결을 시도하면 예외가 발생한다")
+        @Test
+        void link_fail_organizationDocumentNotFound() {
+            // given
+            OrganizationDocumentLinkRequest request = new OrganizationDocumentLinkRequest(
+                savedCrewDocument.getUuid(),
+                UUID.randomUUID()
+            );
+
+            // when & then
+            assertThatThrownBy(() -> organizationDocumentService.link(request))
+                .isInstanceOf(WikiException.class);
+        }
+    }
+}


### PR DESCRIPTION
# 기존 조직 문서를 크루 문서에 연결하는 기능 구현

## 📌 문제 상황

현재 조직 등록 시 "이미 존재하는 조직을 드롭다운에서 찾아 등록하기" 기능이 작동하지 않는 문제가 있었습니다.

### 원인
- 기존 `POST /organization` API는 **신규 조직 문서 생성 및 연결**만 수행
- 이미 존재하는 조직의 UUID로 요청 시, 중복 생성을 시도하여 **409 Conflict** 오류 발생
- 기존 조직을 단순히 크루 문서에 연결만 하는 기능이 없었음

## 💡 해결 방법

### 선택한 방식: 연결 전용 API 추가 (a안)

기존 조직 문서를 크루 문서에 연결만 하는 별도 API를 추가했습니다.

**선택 이유:**
- ✅ 프론트엔드 변경 사항 최소화
- ✅ 빠른 배포 가능
- ✅ 명확한 책임 분리 (생성 vs 연결)
- ✅ RESTful하게 각 엔드포인트가 단일 책임을 가짐

**고려했던 b안 (현재 API에서 분기 처리):**
- 장점: API 엔드포인트 수 유지
- 단점: 기존 API 동작 변경으로 인한 리스크, 프론트엔드 수정 필요


### 4. 테스트 코드
**`OrganizationDocumentServiceTest.java`**
- ✅ 성공적으로 기존 조직 문서를 크루 문서와 연결
- ✅ 존재하지 않는 크루 문서 UUID로 연결 시도 시 예외 발생
- ✅ 존재하지 않는 조직 문서 UUID로 연결 시도 시 예외 발생
