### PR TITLE
feat: 조직 문서를 조회할 때 연결된 크루 문서 목록도 함께 반환하도록 기능을 구현

### DIFF
--- a/src/main/java/com/wooteco/wiki/organizationdocument/dto/response/LinkedCrewDocumentResponse.java
+++ b/src/main/java/com/wooteco/wiki/organizationdocument/dto/response/LinkedCrewDocumentResponse.java
@@ -1,0 +1,17 @@
+package com.wooteco.wiki.organizationdocument.dto.response;
+
+import com.wooteco.wiki.document.domain.CrewDocument;
+import java.util.UUID;
+
+public record LinkedCrewDocumentResponse(
+        UUID documentUuid,
+        String title
+) {
+
+    public LinkedCrewDocumentResponse(CrewDocument crewDocument) {
+        this(
+                crewDocument.getUuid(),
+                crewDocument.getTitle()
+        );
+    }
+}

--- a/src/main/java/com/wooteco/wiki/organizationdocument/dto/response/OrganizationDocumentAndEventResponse.java
+++ b/src/main/java/com/wooteco/wiki/organizationdocument/dto/response/OrganizationDocumentAndEventResponse.java
@@ -14,13 +14,15 @@ public record OrganizationDocumentAndEventResponse(
         String contents,
         String writer,
         LocalDateTime generateTime,
-        List<OrganizationEventResponse> organizationEventResponses
+        List<OrganizationEventResponse> organizationEventResponses,
+        List<LinkedCrewDocumentResponse> linkedCrewDocuments
 ) {
 
     public OrganizationDocumentAndEventResponse(
             OrganizationDocument organizationDocument,
-            List<OrganizationEventResponse> organizationEventResponses
+            List<OrganizationEventResponse> organizationEventResponses,
+            List<LinkedCrewDocumentResponse> linkedCrewDocuments
     ) {
-        this(organizationDocument.getId(), organizationDocument.getUuid(), organizationDocument.getTitle(), organizationDocument.getContents(), organizationDocument.getWriter(), organizationDocument.getGenerateTime(), organizationEventResponses);
+        this(organizationDocument.getId(), organizationDocument.getUuid(), organizationDocument.getTitle(), organizationDocument.getContents(), organizationDocument.getWriter(), organizationDocument.getGenerateTime(), organizationEventResponses, linkedCrewDocuments);
     }
 }

--- a/src/main/java/com/wooteco/wiki/organizationdocument/repository/DocumentOrganizationLinkRepository.java
+++ b/src/main/java/com/wooteco/wiki/organizationdocument/repository/DocumentOrganizationLinkRepository.java
@@ -19,5 +19,7 @@ public interface DocumentOrganizationLinkRepository extends JpaRepository<Docume
 
     List<DocumentOrganizationLink> findAllByCrewDocument(CrewDocument crewDocument);
 
+    List<DocumentOrganizationLink> findAllByOrganizationDocument(OrganizationDocument organizationDocument);
+
     void deleteAllByCrewDocument(CrewDocument crewDocument);
 }

--- a/src/main/java/com/wooteco/wiki/organizationdocument/repository/DocumentOrganizationLinkRepository.java
+++ b/src/main/java/com/wooteco/wiki/organizationdocument/repository/DocumentOrganizationLinkRepository.java
@@ -6,6 +6,8 @@ import com.wooteco.wiki.organizationdocument.domain.OrganizationDocument;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface DocumentOrganizationLinkRepository extends JpaRepository<DocumentOrganizationLink, Long> {
 
@@ -19,7 +21,11 @@ public interface DocumentOrganizationLinkRepository extends JpaRepository<Docume
 
     List<DocumentOrganizationLink> findAllByCrewDocument(CrewDocument crewDocument);
 
-    List<DocumentOrganizationLink> findAllByOrganizationDocument(OrganizationDocument organizationDocument);
+    @Query("SELECT documentOrganizationLink FROM DocumentOrganizationLink documentOrganizationLink " +
+            "JOIN FETCH documentOrganizationLink.crewDocument " +
+            "WHERE documentOrganizationLink.organizationDocument = :organizationDocument")
+    List<DocumentOrganizationLink> findAllByOrganizationDocumentWithCrewDocument(
+            @Param("organizationDocument") OrganizationDocument organizationDocument);
 
     void deleteAllByCrewDocument(CrewDocument crewDocument);
 }

--- a/src/main/java/com/wooteco/wiki/organizationdocument/service/OrganizationDocumentService.java
+++ b/src/main/java/com/wooteco/wiki/organizationdocument/service/OrganizationDocumentService.java
@@ -83,8 +83,8 @@ public class OrganizationDocumentService {
                 .stream()
                 .map(OrganizationEventResponse::new)
                 .toList();
-        List<LinkedCrewDocumentResponse> linkedCrewDocuments = documentOrganizationLinkRepository.findAllByOrganizationDocument(
-                        organizationDocument)
+        List<LinkedCrewDocumentResponse> linkedCrewDocuments = documentOrganizationLinkRepository
+                .findAllByOrganizationDocumentWithCrewDocument(organizationDocument)
                 .stream()
                 .map(link -> new LinkedCrewDocumentResponse(link.getCrewDocument()))
                 .toList();

--- a/src/main/java/com/wooteco/wiki/organizationdocument/service/OrganizationDocumentService.java
+++ b/src/main/java/com/wooteco/wiki/organizationdocument/service/OrganizationDocumentService.java
@@ -12,8 +12,10 @@ import com.wooteco.wiki.organizationdocument.domain.OrganizationDocument;
 import com.wooteco.wiki.organizationdocument.dto.request.OrganizationDocumentCreateRequest;
 import com.wooteco.wiki.organizationdocument.dto.request.OrganizationDocumentLinkRequest;
 import com.wooteco.wiki.organizationdocument.dto.request.OrganizationDocumentUpdateRequest;
+import com.wooteco.wiki.organizationdocument.dto.response.LinkedCrewDocumentResponse;
 import com.wooteco.wiki.organizationdocument.dto.response.OrganizationDocumentAndEventResponse;
 import com.wooteco.wiki.organizationdocument.dto.response.OrganizationDocumentResponse;
+import com.wooteco.wiki.organizationdocument.repository.DocumentOrganizationLinkRepository;
 import com.wooteco.wiki.organizationdocument.repository.OrganizationDocumentRepository;
 import com.wooteco.wiki.organizationevent.dto.response.OrganizationEventResponse;
 import com.wooteco.wiki.organizationevent.repository.OrganizationEventRepository;
@@ -33,6 +35,7 @@ public class OrganizationDocumentService {
     private final OrganizationEventRepository organizationEventRepository;
     private final DocumentRepository documentRepository;
     private final DocumentOrganizationLinkService documentOrganizationLinkService;
+    private final DocumentOrganizationLinkRepository documentOrganizationLinkRepository;
     private final CrewDocumentRepository crewDocumentRepository;
     private final HistoryService historyService;
 
@@ -80,7 +83,12 @@ public class OrganizationDocumentService {
                 .stream()
                 .map(OrganizationEventResponse::new)
                 .toList();
-        return new OrganizationDocumentAndEventResponse(organizationDocument, organizationEventResponses);
+        List<LinkedCrewDocumentResponse> linkedCrewDocuments = documentOrganizationLinkRepository.findAllByOrganizationDocument(
+                        organizationDocument)
+                .stream()
+                .map(link -> new LinkedCrewDocumentResponse(link.getCrewDocument()))
+                .toList();
+        return new OrganizationDocumentAndEventResponse(organizationDocument, organizationEventResponses, linkedCrewDocuments);
     }
 
     private CrewDocument getCrewDocument(UUID uuid) {


### PR DESCRIPTION
# PR Summary - feat/156

## 📌 개요

조직 문서 조회 시 연결된 크루 문서 목록을 함께 제공하는 기능 구현

## 🎯 주요 변경 사항

### 1. 조직 문서 조회 API 응답 확장

**기존 동작**
- 조직 문서 조회 시 문서 정보와 이벤트 목록만 반환
- 해당 조직에 속한 크루원(크루 문서) 정보를 알 수 없음

**개선 사항**
- 조직 문서 조회 시 연결된 크루 문서 목록도 함께 반환
- 크루 문서의 UUID와 제목을 포함하여 응답

**API 엔드포인트**
```
GET /organization/uuid/{uuidText}
```

**응답 예시**
```json
{
  "organizationDocumentId": 1,
  "organizationDocumentUuid": "...",
  "title": "조직 문서 제목",
  "contents": "...",
  "writer": "...",
  "generateTime": "...",
  "organizationEventResponses": [...],
  "linkedCrewDocuments": [
    {
      "documentUuid": "crew-uuid-1",
      "title": "크루원1"
    },
    {
      "documentUuid": "crew-uuid-2",
      "title": "크루원2"
    }
  ]
}
```

## 🏗️ 구현 내용

### 1. DTO 추가
**LinkedCrewDocumentResponse.java** (신규 생성)
- 크루 문서의 핵심 정보만 담는 간단한 응답 DTO
- 필드: `documentUuid`, `title`
- 경량화된 응답으로 성능 최적화

### 2. 응답 객체 확장
**OrganizationDocumentAndEventResponse.java** (수정)
- `linkedCrewDocuments` 필드 추가
- 기존 생성자에 크루 문서 목록 파라미터 추가

### 3. Repository 메서드 추가
**DocumentOrganizationLinkRepository.java** (수정)
- `findAllByOrganizationDocument()` 메서드 추가
- OrganizationDocument 엔티티로 연결된 모든 링크 조회

### 4. Service 로직 개선
**OrganizationDocumentService.java** (수정)
- `findByUuid()` 메서드에 크루 문서 조회 로직 추가
- DocumentOrganizationLink를 통해 연결된 크루 문서 목록 조회
- LinkedCrewDocumentResponse로 변환하여 응답에 포함

## 📁 변경된 파일

### 신규 추가
- `LinkedCrewDocumentResponse.java` - 크루 문서 간단 응답 DTO

### 수정
- `OrganizationDocumentAndEventResponse.java` - 크루 문서 목록 필드 추가
- `DocumentOrganizationLinkRepository.java` - OrganizationDocument 기준 조회 메서드 추가
- `OrganizationDocumentService.java` - 크루 문서 조회 로직 추가
## 🔗 관련 이슈

#156
