### PR TITLE
[FEAT]: 전체 문서 제목 조회 API 추가

### DIFF
--- a/src/main/java/com/wooteco/wiki/document/controller/DocumentController.java
+++ b/src/main/java/com/wooteco/wiki/document/controller/DocumentController.java
@@ -56,6 +56,13 @@ public class DocumentController {
         return ApiResponseGenerator.success(convertToResponse(responses));
     }
 
+    @Operation(summary = "위키 글 제목 전체 조회", description = "모든 위키 글의 제목과 UUID를 조회합니다.")
+    @GetMapping("/titles")
+    public ApiResponse<SuccessBody<List<DocumentTitleListResponse>>> findAllTitles() {
+        List<DocumentTitleListResponse> response = documentService.findAllTitles();
+        return ApiResponseGenerator.success(response);
+    }
+
     @Operation(summary = "제목으로 위키 글 조회", description = "제목을 통해 위키 글을 조회합니다.")
     @GetMapping("title/{title}")
     public ApiResponse<SuccessBody<DocumentResponse>> get(@PathVariable String title) {

--- a/src/main/java/com/wooteco/wiki/document/domain/dto/DocumentTitleListResponse.java
+++ b/src/main/java/com/wooteco/wiki/document/domain/dto/DocumentTitleListResponse.java
@@ -1,0 +1,9 @@
+package com.wooteco.wiki.document.domain.dto;
+
+import java.util.UUID;
+
+public record DocumentTitleListResponse(
+        String title,
+        UUID uuid
+) {
+}

--- a/src/main/java/com/wooteco/wiki/document/repository/DocumentRepository.java
+++ b/src/main/java/com/wooteco/wiki/document/repository/DocumentRepository.java
@@ -21,7 +21,6 @@ public interface DocumentRepository extends JpaRepository<Document, Long> {
     @Query("""
         SELECT new com.wooteco.wiki.document.domain.dto.DocumentTitleListResponse(d.title, d.uuid)
         FROM Document d
-        ORDER BY d.title
         """)
     List<DocumentTitleListResponse> findAllTitles();
 

--- a/src/main/java/com/wooteco/wiki/document/repository/DocumentRepository.java
+++ b/src/main/java/com/wooteco/wiki/document/repository/DocumentRepository.java
@@ -1,6 +1,7 @@
 package com.wooteco.wiki.document.repository;
 
 import com.wooteco.wiki.document.domain.Document;
+import com.wooteco.wiki.document.domain.dto.DocumentTitleListResponse;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -16,6 +17,13 @@ public interface DocumentRepository extends JpaRepository<Document, Long> {
     Boolean existsByTitle(String title);
 
     List<Document> findAllByTitleStartingWithOrderByTitle(String keyWord);
+
+    @Query("""
+        SELECT new com.wooteco.wiki.document.domain.dto.DocumentTitleListResponse(d.title, d.uuid)
+        FROM Document d
+        ORDER BY d.title
+        """)
+    List<DocumentTitleListResponse> findAllTitles();
 
     Optional<Document> findByUuid(UUID uuid);
 

--- a/src/main/java/com/wooteco/wiki/document/service/DocumentService.java
+++ b/src/main/java/com/wooteco/wiki/document/service/DocumentService.java
@@ -27,7 +27,6 @@ public class DocumentService {
         return documentRepository.findAll(pagingRequest.toPageable());
     }
 
-    @Transactional(readOnly = true)
     public List<DocumentTitleListResponse> findAllTitles() {
         return documentRepository.findAllTitles();
     }
@@ -53,4 +52,3 @@ public class DocumentService {
         documentRepository.saveAll(documents);
     }
 }
-

--- a/src/main/java/com/wooteco/wiki/document/service/DocumentService.java
+++ b/src/main/java/com/wooteco/wiki/document/service/DocumentService.java
@@ -1,6 +1,7 @@
 package com.wooteco.wiki.document.service;
 
 import com.wooteco.wiki.document.domain.Document;
+import com.wooteco.wiki.document.domain.dto.DocumentTitleListResponse;
 import com.wooteco.wiki.document.domain.dto.DocumentUuidResponse;
 import com.wooteco.wiki.document.repository.DocumentRepository;
 import com.wooteco.wiki.global.common.PagingRequest;
@@ -24,6 +25,11 @@ public class DocumentService {
     @Transactional(readOnly = true)
     public Page<Document> findAll(PagingRequest pagingRequest) {
         return documentRepository.findAll(pagingRequest.toPageable());
+    }
+
+    @Transactional(readOnly = true)
+    public List<DocumentTitleListResponse> findAllTitles() {
+        return documentRepository.findAllTitles();
     }
 
     public DocumentUuidResponse getUuidByTitle(String title) {

--- a/src/test/java/com/wooteco/wiki/document/service/DocumentServiceTest.java
+++ b/src/test/java/com/wooteco/wiki/document/service/DocumentServiceTest.java
@@ -2,6 +2,7 @@ package com.wooteco.wiki.document.service;
 
 import static com.wooteco.wiki.global.exception.ErrorCode.DOCUMENT_NOT_FOUND;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.wooteco.wiki.admin.service.CrewDocumentService;
@@ -9,6 +10,7 @@ import com.wooteco.wiki.document.domain.CrewDocument;
 import com.wooteco.wiki.document.domain.Document;
 import com.wooteco.wiki.document.domain.dto.CrewDocumentCreateRequest;
 import com.wooteco.wiki.document.domain.dto.DocumentResponse;
+import com.wooteco.wiki.document.domain.dto.DocumentTitleListResponse;
 import com.wooteco.wiki.document.domain.dto.DocumentUuidResponse;
 import com.wooteco.wiki.document.fixture.CrewDocumentFixture;
 import com.wooteco.wiki.document.repository.DocumentRepository;
@@ -209,6 +211,48 @@ class DocumentServiceTest {
             WikiException ex = assertThrows(WikiException.class,
                     () -> documentService.findAll(pageRequestDto));
             assertThat(ex.getErrorCode()).isEqualTo(ErrorCode.PAGE_BAD_REQUEST);
+        }
+    }
+
+    @Nested
+    @DisplayName("전체 문서 제목 조회 기능")
+    class FindAllTitles {
+
+        @DisplayName("문서가 존재하면 제목과 UUID 목록을 반환한다.")
+        @Test
+        void findAllTitles_success_bySomeData() {
+            // given
+            UUID firstUuid = UUID.randomUUID();
+            UUID secondUuid = UUID.randomUUID();
+
+            crewDocumentService.create(
+                    CrewDocumentFixture.createDocumentCreateRequest("title1", "content1", "writer1", 10L, firstUuid));
+            crewDocumentService.create(
+                    CrewDocumentFixture.createDocumentCreateRequest("title2", "content2", "writer2", 11L, secondUuid));
+
+            // when
+            List<DocumentTitleListResponse> result = documentService.findAllTitles();
+
+            // then
+            assertSoftly(softly -> {
+                softly.assertThat(result).hasSize(2);
+                softly.assertThat(result)
+                        .extracting(DocumentTitleListResponse::title)
+                        .containsExactly("title1", "title2");
+                softly.assertThat(result)
+                        .extracting(DocumentTitleListResponse::uuid)
+                        .containsExactly(firstUuid, secondUuid);
+            });
+        }
+
+        @DisplayName("문서가 존재하지 않으면 빈 리스트를 반환한다.")
+        @Test
+        void findAllTitles_success_byNoData() {
+            // when
+            List<DocumentTitleListResponse> result = documentService.findAllTitles();
+
+            // then
+            Assertions.assertThat(result).isEmpty();
         }
     }
 

--- a/src/test/java/com/wooteco/wiki/document/service/DocumentServiceTest.java
+++ b/src/test/java/com/wooteco/wiki/document/service/DocumentServiceTest.java
@@ -21,7 +21,6 @@ import com.wooteco.wiki.history.repository.HistoryRepository;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
-import org.assertj.core.api.Assertions;
 import org.assertj.core.api.SoftAssertions;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.BeforeEach;
@@ -252,7 +251,7 @@ class DocumentServiceTest {
             List<DocumentTitleListResponse> result = documentService.findAllTitles();
 
             // then
-            Assertions.assertThat(result).isEmpty();
+            assertThat(result).isEmpty();
         }
     }
 
@@ -279,7 +278,7 @@ class DocumentServiceTest {
         Document updated1 = documentRepository.findById(doc1.getId()).get();
         Document updated2 = documentRepository.findById(doc2.getId()).get();
 
-        Assertions.assertThat(updated1.getViewCount()).isEqualTo(5);
-        Assertions.assertThat(updated2.getViewCount()).isEqualTo(10);
+        assertThat(updated1.getViewCount()).isEqualTo(5);
+        assertThat(updated2.getViewCount()).isEqualTo(10);
     }
 }


### PR DESCRIPTION
### 관련 이슈
- Closes #167

### 작업 내용
- 전체 문서 제목 조회 API 추가
  - `GET /document/titles`
- 전체 문서의 `title`, `uuid`만 반환하는 `DocumentTitleListResponse` 추가
- 전체 문서 조회 쿼리 추가
  - `title`, `uuid`만 조회
- 전체 문서 제목 조회 서비스 테스트 추가